### PR TITLE
feat: Enhance APIs with file URL path support

### DIFF
--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -13,6 +13,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { isRegExp } from 'node:util';
+import { URL } from 'node:url';
 import { lsTypes }  from './lsTypes';
 import type {
   LsEntries,
@@ -21,6 +22,46 @@ import type {
   LsTypesKeys,
   LsTypesValues
 } from '../types';
+
+/**
+ * Converts a file URL to a file path.
+ * 
+ * This function is similar to Node.js'
+ * [`url.fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl)
+ * function, but with added support for relative file paths (e.g., "file:./foo").
+ * If the input URL does not adhere to the file URL scheme or if it contains
+ * unsupported formats, such as providing not `file:` protocol or invalid path
+ * structures, an error will be thrown.
+ * 
+ * @param url - The file URL to convert. It can be either an instance of `URL`
+ *              or a string representing a file URL and must starts with `"file:"`
+ *              protocol.
+ * @returns     A string representing the corresponding file path.
+ * @throws {URIError} If the URL is not a valid file URL or if it contains
+ *                    unsupported formats.
+ * 
+ * @example
+ * // Convert a file URL to a file path
+ * const filePath = fileUrlToPath('file:///path/to/file.txt');
+ * console.log(filePath); // Output: "/path/to/file.txt"
+ * 
+ * @example
+ * // Handle relative file paths
+ * const filePath = fileUrlToPath('file:./relative/file.txt');
+ * console.log(filePath); // Output: "./relative/file.txt"
+ *
+ * @since 1.0.0
+ * @see   {@link https://nodejs.org/api/url.html#urlfileurltopathurl url.fileURLToPath}
+ *
+ * @internal
+ */
+function fileUrlToPath(url: URL | string): string {
+  if ((url instanceof URL && url.protocol !== 'file:')
+      || (typeof url === 'string' && !/^file:(\/\/?|\.\.?\/*)/.test(url))) {
+    throw new URIError('Invalid URL file scheme');
+  }
+  return (url instanceof URL) ? url.pathname : url.replace(/^file:/, '');
+}
 
 /**
  * Lists files and/or directories in a specified directory path, filtering by a

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -25,30 +25,30 @@ import type {
 
 /**
  * Converts a file URL to a file path.
- * 
+ *
  * This function is similar to Node.js'
  * [`url.fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl)
- * function, but with added support for relative file paths (e.g., "file:./foo").
+ * function, but with added support for relative file paths (e.g., `"file:./foo"`).
  * If the input URL does not adhere to the file URL scheme or if it contains
- * unsupported formats, such as providing not `file:` protocol or invalid path
+ * unsupported formats, such as providing unsupported protocols or invalid path
  * structures, an error will be thrown.
- * 
+ *
  * @param url - The file URL to convert. It can be either an instance of `URL`
  *              or a string representing a file URL and must starts with `"file:"`
  *              protocol.
  * @returns     A string representing the corresponding file path.
  * @throws {URIError} If the URL is not a valid file URL or if it contains
  *                    unsupported formats.
- * 
+ *
  * @example
  * // Convert a file URL to a file path
  * const filePath = fileUrlToPath('file:///path/to/file.txt');
  * console.log(filePath); // Output: "/path/to/file.txt"
- * 
+ *
  * @example
  * // Handle relative file paths
- * const filePath = fileUrlToPath('file:./relative/file.txt');
- * console.log(filePath); // Output: "./relative/file.txt"
+ * const filePath = fileUrlToPath('file:./path/to/file.txt');
+ * console.log(filePath); // Output: "./path/to/file.txt"
  *
  * @since 1.0.0
  * @see   {@link https://nodejs.org/api/url.html#urlfileurltopathurl url.fileURLToPath}
@@ -72,8 +72,8 @@ function fileUrlToPath(url: URL | string): string {
  * directory names using a regular expression.
  *
  * The additional `options` can be an object or a regex pattern to specify only
- * the {@link LsOptions.match} field. If passed as a `RegExp` object,
- * the additional options for reading the directory will uses default options.
+ * the {@link LsOptions.match match} field. If passed as a `RegExp` object, the rest
+ * options (except the `match` field) for reading the directory will uses default options.
  *
  * If the `options` argument not specified (or `undefined`), then it uses the
  * default value:
@@ -86,17 +86,36 @@ function fileUrlToPath(url: URL | string): string {
  * }
  * ```
  *
- * @param dirpath - The directory path to search.
- * @param options - Additional options for reading the directory.
+ * <br>
+ * <details>
+ * <summary><b>History</b></summary>
+ *
+ * ### 1.0.0
+ * As of version 1.0.0, this function now accepts file URL paths. This can be
+ * either a string URL path or a `URL` object, and it must follow the `'file:'` protocol.
+ * An `URIError` will be thrown if the specified file URL path has invalid file
+ * URL syntax or is used with unsupported protocols.
+ *
+ * ### 0.1.0
+ * Added in version 0.1.0.
+ *
+ * </details>
+ *
+ * @param dirpath - The directory path to search, must be a **Node** path
+ *                  (i.e., similar to POSIX path) or a valid file URL path.
+ * @param options - Additional options for reading the directory. Refer to
+ *                  {@link LsOptions} documentation for more details.
  * @param type - A type to specify the returned file system type to be included.
  *               If not specified or set to `0`, then it will includes all types
  *               (including regular files and directories).
  *               See {@link !lsTypes~lsTypes lsTypes} to check all supported types.
  *
  * @returns A promise that resolves with an array of string representing the
- *          entries result or an empty array if any files and directories doesn't
- *          match with the specified filter options.
+ *          entries result excluding `'.'` and `'..'` or an empty array (`[]`)
+ *          if any files and directories does not match with the specified filter options.
  * @throws {Error} If there is an error occurred while reading a directory.
+ * @throws {URIError} If the given URL path contains invalid file URL scheme or
+ *                    using unsupported protocols.
  *
  * @example
  * // List all installed packages in 'node_modules' directory
@@ -222,8 +241,8 @@ export async function ls(
  * directory names using a regular expression.
  *
  * The additional `options` can be an object or a regex pattern to specify only
- * the {@link LsOptions.match} field. If passed as a `RegExp` object,
- * the additional options for reading the directory will uses default options.
+ * the {@link LsOptions.match match} field. If passed as a `RegExp` object, the rest
+ * options (except the `match` field) for reading the directory will uses default options.
  *
  * If the `options` argument not specified (or `undefined`), then it uses the
  * default value:
@@ -236,13 +255,32 @@ export async function ls(
  * }
  * ```
  *
- * @param dirpath - The directory path to search.
- * @param options - Additional options for reading the directory.
+ * <br>
+ * <details>
+ * <summary><b>History</b></summary>
+ *
+ * ### 1.0.0
+ * As of version 1.0.0, this function now accepts file URL paths. This can be
+ * either a string URL path or a `URL` object, and it must follow the `'file:'` protocol.
+ * An `URIError` will be thrown if the specified file URL path has invalid file
+ * URL syntax or is used with unsupported protocols.
+ *
+ * ### 0.1.0
+ * Added in version 0.1.0.
+ *
+ * </details>
+ *
+ * @param dirpath - The directory path to search, must be a **Node** path
+ *                  (i.e., similar to POSIX path) or a valid file URL path.
+ * @param options - Additional options for reading the directory. Refer to
+ *                  {@link LsOptions} documentation for more details.
  *
  * @returns A promise that resolves with an array of string representing the
- *          entries result or an empty array if any files doesn't match with
- *          the specified filter options.
+ *          entries result excluding `'.'` and `'..'` or an empty array (`[]`)
+ *          if any files and directories does not match with the specified filter options.
  * @throws {Error} If there is an error occurred while reading a directory.
+ * @throws {URIError} If the given URL path contains invalid file URL scheme or
+ *                    using unsupported protocols.
  *
  * @example
  * // List all JavaScript files in current directory recursively,
@@ -269,13 +307,13 @@ export async function lsFiles(
  * Lists files in the specified directory path, filtering by a regular
  * expression pattern.
  *
- * The returned entries are configurable using the additional `options`, such as
- * listing recursively to subdirectories, and filter specific file and/or
+ * The returned entries are configurable using the additional {@link LsOptions options},
+ * such as listing recursively to subdirectories, and filter specific file and/or
  * directory names using a regular expression.
  *
- * The additional `options` can be an object or a regex pattern to specify only the
- * `match` field. If passed as a `RegExp` object, the additional options for reading
- * the directory will uses default options.
+ * The additional `options` can be an object or a regex pattern to specify only
+ * the {@link LsOptions.match match} field. If passed as a `RegExp` object, the rest
+ * options (except the `match` field) for reading the directory will uses default options.
  *
  * If the `options` argument not specified (or `undefined`), then it uses the
  * default value:
@@ -288,13 +326,32 @@ export async function lsFiles(
  * }
  * ```
  *
- * @param dirpath - The directory path to search.
- * @param options - Additional options for reading the directory.
+ * <br>
+ * <details>
+ * <summary><b>History</b></summary>
+ *
+ * ### 1.0.0
+ * As of version 1.0.0, this function now accepts file URL paths. This can be
+ * either a string URL path or a `URL` object, and it must follow the `'file:'` protocol.
+ * An `URIError` will be thrown if the specified file URL path has invalid file
+ * URL syntax or is used with unsupported protocols.
+ *
+ * ### 0.1.0
+ * Added in version 0.1.0.
+ *
+ * </details>
+ *
+ * @param dirpath - The directory path to search, must be a **Node** path
+ *                  (i.e., similar to POSIX path) or a valid file URL path.
+ * @param options - Additional options for reading the directory. Refer to
+ *                  {@link LsOptions} documentation for more details.
  *
  * @returns A promise that resolves with an array of string representing the
- *          entries result or an empty array if any directories doesn't match
- *          with the specified filter options.
+ *          entries result excluding `'.'` and `'..'` or an empty array (`[]`)
+ *          if any files and directories does not match with the specified filter options.
  * @throws {Error} If there is an error occurred while reading a directory.
+ * @throws {URIError} If the given URL path contains invalid file URL scheme or
+ *                    using unsupported protocols.
  *
  * @example
  * // Search and list directory named 'foo' in 'src' directory

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -148,7 +148,7 @@ export async function ls(
   // Resolve its absolute path
   absdirpath = path.isAbsolute(<string> dirpath)
     ? <string> dirpath
-    : path.resolve(<string> dirpath);
+    : path.posix.resolve(<string> dirpath);
 
   if (isRegExp(options)) {
     match = options;

--- a/test/lib/simpletest.js
+++ b/test/lib/simpletest.js
@@ -62,5 +62,9 @@ module.exports = {
   deepEq: assert.deepStrictEqual,
   notDeepEq: assert.notDeepStrictEqual,
   throws: assert.throws,
-  rejects: assert.rejects
+  doesNotThrow: assert.doesNotThrow,
+  rejects: assert.rejects,
+  doesNotReject: assert.doesNotReject,
+  match: assert.match,
+  doesNotMatch: assert.doesNotMatch
 };

--- a/test/lsfnd.spec.cjs
+++ b/test/lsfnd.spec.cjs
@@ -1,29 +1,51 @@
-const { join, basename } = require('node:path');
-const { ls, lsFiles, lsDirs } = require('..');
-const { it, rejects, deepEq } = require('./lib/simpletest');
+/**
+ * A test module for `lsfnd` package designed for CommonJS module (CJS).
+ * @author Ryuu Mitsuki (https://github.com/mitsuki31)
+ */
 
-console.log(`\n\x1b[1m${basename(__filename)}:\x1b[0m`);
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { ls, lsFiles, lsDirs } = require('..');
+const { it, rejects, doesNotReject, deepEq } = require('./lib/simpletest');
+
+const rootDir = path.resolve('..');
+const rootDirPosix = path.posix.resolve('..');
+
+console.log(`\n\x1b[1m${path.basename(__filename)}:\x1b[0m`);
 
 it('test `ls` function by listing this file directory', async () => {
   const results = await ls(__dirname, {}, 0);
   const expected = [ 'lib', 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
-    .map((e) => join(__dirname, e));
+    .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
 it('test `lsFiles` function by listing this file directory', async () => {
   const results = await lsFiles(__dirname);
   const expected = [ 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
-    .map((e) => join(__dirname, e));
+    .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
+}, false);
+
+it('list root directory using URL object', async () => {
+  await doesNotReject(ls(pathToFileURL(rootDirPosix)), URIError);
+}, false);
+
+it('list root directory using file URL path', async () => {
+  await doesNotReject(ls('file:'.concat(rootDirPosix)), URIError);
 }, false);
 
 it('test `lsDirs` function by listing this file directory', async () => {
   const results = await lsDirs(__dirname);
-  const expected = [ 'lib' ].map((e) => join(__dirname, e));
+  const expected = [ 'lib' ].map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
-it('throws an error if given directory path not exist', async () => {
+it('throws an error if the given directory path not exist', async () => {
   await rejects(ls('./this/is/not/exist/directory/path'), Error);
 }, false);
+
+it('throws an URIError if the given file URL path using unsupported protocol',
+  async () => await rejects(ls('http:'.concat(rootDirPosix)), URIError),
+  false
+);

--- a/test/lsfnd.spec.mjs
+++ b/test/lsfnd.spec.mjs
@@ -1,35 +1,55 @@
-import { join, dirname, basename } from 'node:path';
-import { fileURLToPath } from 'node:url';
+/**
+ * A test module for `lsfnd` package designed for ECMAScript module (ESM).
+ * @author Ryuu Mitsuki (https://github.com/mitsuki31)
+ */
+
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { ls, lsFiles, lsDirs } from '../dist/index.js';
 import test from './lib/simpletest.js';
-const { it, rejects, deepEq } = test;
+const { it, rejects, doesNotReject, deepEq } = test;  // Resolve import from CommonJS module
 
 // Create the '__dirname' and '__filename' variable, because in ESM these are not defined
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve('..');
+const rootDirPosix = path.posix.resolve('..');
 
-console.log(`\n\x1b[1m${basename(__filename)}:\x1b[0m`);
+console.log(`\n\x1b[1m${path.basename(__filename)}:\x1b[0m`);
 
 it('test `ls` function by listing this file directory', async () => {
   const results = await ls(__dirname, {}, 0);
   const expected = [ 'lib', 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
-    .map((e) => join(__dirname, e));
+    .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
 it('test `lsFiles` function by listing this file directory', async () => {
   const results = await lsFiles(__dirname);
   const expected = [ 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
-    .map((e) => join(__dirname, e));
+    .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
 it('test `lsDirs` function by listing this file directory', async () => {
   const results = await lsDirs(__dirname);
-  const expected = [ 'lib' ].map((e) => join(__dirname, e));
+  const expected = [ 'lib' ].map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
-it('throws an error if given directory path not exist', async () => {
+it('list root directory using URL object', async () => {
+  await doesNotReject(ls(pathToFileURL(rootDirPosix)), URIError);
+}, false);
+
+it('list root directory using file URL path', async () => {
+  await doesNotReject(ls('file:'.concat(rootDirPosix)), URIError);
+}, false);
+
+it('throws an error if the given directory path not exist', async () => {
   await rejects(ls('./this/is/not/exist/directory/path'), Error);
 }, false);
+
+it('throws an URIError if the given file URL path using unsupported protocol',
+  async () => await rejects(ls('http:'.concat(rootDirPosix)), URIError),
+  false
+);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -113,18 +113,18 @@ export declare interface LsOptions {
 // ====== APIs ===== //
 
 export declare function ls(
-  dirpath: string,
+  dirpath: string | URL,
   options?: LsOptions | RegExp | undefined,
   type?: LsTypes | LsTypesKeys | LsTypesValues | undefined
 ): Promise<LsResult>
 
 export declare function lsFiles(
-  dirpath: string,
+  dirpath: string | URL,
   options?: LsOptions | RegExp | undefined
 ): Promise<LsResult>
 
 export declare function lsDirs(
-  dirpath: string,
+  dirpath: string | URL,
   options?: LsOptions | RegExp | undefined
 ): Promise<LsResult>
 


### PR DESCRIPTION
## Summary

This pull request brings new features, enhance the functionality APIs, improve documentation, and ensure compatibility across different environments.

## Notable Changes

- Implemented an internal function to convert file URLs. This function behaves similarly to NodeJS' `url.fileURLToPath` function but with added support for relative paths. It throws an `URIError` for non-`file` protocols or invalid path structures. This function will be utilized in `ls*` functions to support file URL paths.
- Improved and updated the documentation for the APIs. Additionally, a history section has been added to document changes in each version.
- Added support for file URLs in all `ls*` functions. Now, these functions can accept string URL paths or URL objects with the `'file:'` protocol. However, please note that only the `'file:'` protocol is currently supported for directory resolution and listing.
- Fixed an issue with absolute path resolution on Windows systems. The resolution process now ensures that the path passed to `fs.readdir` adheres to the required format.
- Included several assert functions from the `node:assert` module to enhance test coverage.
- Added new test cases to ensure the correct behavior of the APIs regarding file URL paths and `URL` objects with the `'file:'` protocol. Also, tests have been added to verify that an `URIError` is correctly thrown when unsupported protocols are used.

## Description

### New Features

This pull request brings a new feature to all `ls*` functions, that is a support to file URL path for `dirpath` parameter. It accepts both a string URL path or a `URL` object by following the `'file:'` protocol, utilizing an internal function called `fileUrlToPath` to convert the file URLs.

_"Why don't use the inbuilt function provided by Node.js itself?"_ Well, this function might behave the same with `url.fileURLToPath` function from `node:url` module, but this function are supports relative paths. Unlike `url.fileURLToPath` inbuilt function that doesn't accepts a string URL with relative path, attempting to do so will causing an error.

Here's some examples on how to use the new feature:

```js
// List all files in 'fooBar' directory relative from current directory
lsFiles('file:./fooBar').then(entries => console.log(entries));
```

```js
const path = require('node:path');
const { pathToFileURL } = require('node:url');
// ESM: import * as path from 'node:path';
//      import { pathToFileURL } from 'node:url';

// List all installed packages inside 'node_modules' directory
ls(pathToFileURL(path.posix.resolve('node_modules')), {
  recursive: false,
  exclude: /\.bin/
}, lsTypes.LS_D).then(entries => console.log(entries));
```

This new feature has been tested and the tests code are available in the project. If having any issues while using the feature, [report to us](https://github.com/mitsuki31/lsfnd/issues/new) by providing the issue details.

### Test Environments

Introduced new test cases to ensure that the APIs correctly handle file URL paths and `URL` objects with the `'file:'` protocol and also ensured that the APIs throws a `URIError` when provided with URL paths using unsupported protocols.

### Documentation

Added a history section to document changes made to the APIs in each version and improved the documentation for the APIs.