### PR TITLE
fix(ls): Allow explicit `null` value for options parameter

### DIFF
--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -173,18 +173,19 @@ export async function ls(
     match = options;
     exclude = undefined;
     options = { encoding: 'utf8', recursive: false };
-  } else if (typeof options === 'object') {
+  } else if (typeof options === 'undefined' || options === null) {
+    options = { encoding: 'utf8', recursive: false };
+    match = /.+/;
+  } else if (options && typeof options === 'object' && !Array.isArray(options)) {
     match = (typeof options!.match === 'string')
       ? new RegExp(options!.match)
       : (isRegExp(options!.match) ? options!.match : /.+/);
     exclude = (typeof options!.exclude === 'string')
       ? new RegExp(options!.exclude)
       : (isRegExp(options!.exclude) ? options!.exclude : undefined);
-  } else if (typeof options === 'undefined' || options === null) {
-    options = { encoding: 'utf8', recursive: false };
-    match = /.+/;
   } else {
-    throw new TypeError('Unknown type of "options": ' + typeof options);
+    throw new TypeError('Unknown type of "options": '
+      + (Array.isArray(options) ? 'array' : typeof options));
   }
 
   let result: LsResult = null;


### PR DESCRIPTION
## Summary

This pull request addresses a type safety issue related to the `options` parameter in all `ls*` functions.

## Details

Previously, the `options` parameter for all `ls*` functions was defined as non-nullable. This meant you couldn't explicitly pass `null` as an argument, even though using `undefined` or an empty object (`{}`) was a valid way to indicate no options.

This change updates the type definition for the `options` parameter to allow `null` as a valid value alongside `undefined`. This provides more flexibility in how you can use the `ls*` functions.

Previously if you write code like this:
```js
const dirs = await ls('./foo', null, lsTypes.LS_D);
```

An error will be thrown from the internal function, with message `Uncaught TypeError: Cannot read properties of null (reading 'match')`. Now after this change, the issue has been fixed and can the `options` parameter is now nullable.

## Benefits

- **Improved type safety:**
  The type definition now accurately reflects the acceptable values for the `options` parameter.
- **Enhanced developer experience:**
  Developers can now explicitly pass `null` to indicate no options, leading to clearer code and potentially fewer runtime errors.
