### PR TITLE
refactor(types): Enhance typings structure and module compatibility

### DIFF
--- a/build.prop.js
+++ b/build.prop.js
@@ -1,13 +1,14 @@
-const { resolve } = require('node:path');
+const { join } = require('node:path');
 /** @type {import('./types/build.prop').BuildPropConfig} */
 module.exports = {
   minify: {
     files: [
       'dist/index.js',
-      'dist/lsfnd.js'
+      'dist/lsfnd.js',
+      'dist/lsTypes.js'
     ]
   },
-  rootDir: resolve(__dirname),
-  outDir: resolve('dist'),
-  tsconfig: 'tsconfig.production.json',
+  rootDir: __dirname,
+  outDir: join(__dirname, 'dist'),
+  tsconfig: 'tsconfig.production.json'
 };

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -17,8 +17,7 @@
  * npx ts-node scripts/build.ts [-ow|--overwrite] [-m|--minify]
  * ```
  *
- * Copyright (c) 2024 Ryuu Mitsuki.
- * Licensed under the MIT license.
+ * Copyright (c) 2024 Ryuu Mitsuki. All rights reserved.
  *
  * @module  scripts/build
  * @author  Ryuu Mitsuki (https://github.com/mitsuki31)
@@ -62,6 +61,7 @@ const legalComments: string = `
  * Copyright (c) ${new Date().getFullYear()} Ryuu Mitsuki. All rights reserved.
  * @author Ryuu Mitsuki (https://github.com/mitsuki31)
  * @license ${pkg.license}
+ * @see [Homepage](${pkg.homepage})
  * @see [Source code](${pkg.repository.url.replace(/^git\+/, '')})
  */
 `.trimStart();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,12 @@
 
 export * from './lsTypes';
 export * from './lsfnd';
+export type {
+  LsTypes,
+  LsTypesInterface,
+  LsTypesKeys,
+  LsTypesValues,
+  LsOptions,
+  LsEntries,
+  LsResult
+} from '../types';

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -19,8 +19,7 @@ import type {
   LsEntries,
   LsResult,
   LsOptions,
-  LsTypesKeys,
-  LsTypesValues
+  LsTypes
 } from '../types';
 
 type Unpack<A> = A extends Array<(infer U)> ? U : A;
@@ -82,7 +81,7 @@ function fileUrlToPath(url: URL | string): string {
  * @internal
  */
 function checkType<N extends null | undefined>(
-  type: lsTypes | LsTypesKeys | LsTypesValues | N,
+  type: LsTypes | N,
   validTypes: Array<(string | number | N)>
 ): void {
   function joinAll(arr: (typeof validTypes), delim: string): string {
@@ -186,11 +185,7 @@ function checkType<N extends null | undefined>(
 export async function ls(
   dirpath: string | URL,
   options?: LsOptions | RegExp | undefined,
-  type?:
-    | lsTypes
-    | LsTypesKeys
-    | LsTypesValues
-    | undefined
+  type?: LsTypes | undefined
 ): Promise<LsResult> {
   let absdirpath: string;
   let match: string | RegExp,
@@ -355,7 +350,7 @@ export async function ls(
  */
 export async function lsFiles(
   dirpath: string | URL,
-  options?: LsOptions | RegExp
+  options?: LsOptions | RegExp | undefined
 ): Promise<LsResult> {
   return ls(dirpath, options, lsTypes.LS_F);
 }
@@ -426,7 +421,7 @@ export async function lsFiles(
  */
 export async function lsDirs(
   dirpath: string | URL,
-  options?: LsOptions | RegExp
+  options?: LsOptions | RegExp | undefined
 ): Promise<LsResult> {
   return ls(dirpath, options, lsTypes.LS_D);
 }

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "strict": true,
     "alwaysStrict": true,
-    "removeComments": true
+    "removeComments": true,
+    "declaration": true
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,8 +3,7 @@
 * Project: lsfnd (https://github.com/mitsuki31/lsfnd.git)  
 * Definitions by: Ryuu Mitsuki (https://github.com/mitsuki31)  
 *
-* Copyright (c) 2024 Ryuu Mitsuki.
-* Licensed under the MIT license.
+* Copyright (c) 2024 Ryuu Mitsuki. All rights reserved.
 *
 * @module  types
 * @author  Ryuu Mitsuki (https://github.com/mitsuki31)
@@ -21,6 +20,7 @@
  * @since 0.1.0
  */
 export declare type LsEntries = Array<string>;
+
 /**
  * This type alias represents the possible return values of the `ls*` functions.
  * It can be either a {@link LsEntries} array containing the list of file paths,
@@ -30,22 +30,23 @@ export declare type LsEntries = Array<string>;
 export declare type LsResult = LsEntries | null;
 
 /**
- * An enum representing different file types.
- * @since 0.1.0
- * @see {@link lsfnd!~lsTypes lsfnd.lsTypes}
- * @see {@link LsTypes}
+ * A combination union types containing all possible values used to specify the
+ *  returned results on {@link !lsfnd~ls ls} function.
+ * @since 1.0.0
  */
-export declare const lsTypes: LsTypes;
+export declare type LsTypes = LsTypesKeys | LsTypesValues;
+
 /**
  * Type representing all possible keys of the {@link lsTypes} enum.
  * @since 0.1.0
- * @see {@link LsTypes}
+ * @see {@link LsTypesInterface}
  */
-export declare type LsTypesKeys = keyof LsTypes;
+export declare type LsTypesKeys = keyof LsTypesInterface;
+
 /**
  * Type representing all possible values of the {@link lsTypes} enum.
  * @since 0.1.0
- * @see {@link LsTypes}
+ * @see {@link LsTypesInterface}
  */
 export declare type LsTypesValues =
   | 0b00   // 0 (interpreted the same as LS_A | 1)
@@ -60,7 +61,7 @@ export declare type LsTypesValues =
  * @interface
  * @since 0.1.0
  */
-export declare interface LsTypes {
+export declare interface LsTypesInterface {
   /**
    * Represents an option to include all file types.
    * @defaultValue `0b01 << 0b00` (`0b01` | `0o01` | `0x01` | `1`)
@@ -87,12 +88,12 @@ export declare interface LsTypes {
 export declare interface LsOptions {
   /**
    * Specifies the character encoding to be used when reading a directory. 
-   * @defaultValue Defaults to `'utf8'` if not provided.
+   * @defaultValue `'utf8'`
    */
   encoding?: BufferEncoding | undefined,
   /**
    * A boolean flag indicating whether to include subdirectories in the listing. 
-   * @defaultValue Defaults to `false` if not provided.
+   * @defaultValue `false`
    */
   recursive?: boolean | undefined,
   /**
@@ -112,17 +113,33 @@ export declare interface LsOptions {
 
 // ====== APIs ===== //
 
+/**
+ * {@inheritDoc !lsTypes~lsTypes}
+ *
+ * @see For more details, refer to {@link !lsTypes~lsTypes lsTypes} enum documentation.
+ */
+export declare const lsTypes: Record<
+  LsTypesKeys,
+  LsTypesValues
+> & Record<
+  LsTypesValues,
+  LsTypesKeys
+>;
+
+/** {@inheritDoc !lsfnd~ls} */
 export declare function ls(
   dirpath: string | URL,
   options?: LsOptions | RegExp | undefined,
-  type?: LsTypes | LsTypesKeys | LsTypesValues | undefined
+  type?: LsTypes | undefined
 ): Promise<LsResult>
 
+/** {@inheritDoc !lsfnd~lsFiles} */
 export declare function lsFiles(
   dirpath: string | URL,
   options?: LsOptions | RegExp | undefined
 ): Promise<LsResult>
 
+/** {@inheritDoc !lsfnd~lsDirs} */
 export declare function lsDirs(
   dirpath: string | URL,
   options?: LsOptions | RegExp | undefined


### PR DESCRIPTION
## Overview

This pull request introduces several improvements and refinements to the `lsfnd` package. The focus is primarily on enhancing the types declaration within the `types` module, making it more organized and adaptable for future development and make this project supports in TypeScript projects with various modules settings. Additionally, it includes optimizations in the build process to minify the `lsTypes` module (forgot to include this module while maintaining #1).

## Notable Changes

- **Types Declaration Refactoring** (6756665):
  - Reorganized and refactored the types declaration in the `types` module for improved maintainability and future development.
  - Restructured type definitions for specific API parameters.
  - Re-exported the `types` module in the main package entry (`index.ts`).
  - Enabled the `declaration` option in the `tsconfig.production.json` file to ensure proper TypeScript typings generation and it's crucial for compatibility in TypeScript project with various modules type, especially for `node*` modules.
  - These changes allow the `lsfnd` package to be correctly imported and used in TypeScript projects with various module settings, including `node16`, `nodenext`, `es5`, `esnext`, and others, in addition to `commonjs`, which was supported in the previous release.

- **Build Process Improvement** (4d48e06):
  - Included the `lsTypes` module to be minified after transpilation from TypeScript during the build process.
  - Other changes are unrelated to this enhancement.

## Summary

These changes significantly improve the organization and maintainability of the `types` module within the `lsfnd` package. By refactoring type declarations and enabling re-exporting, the package is now compatible with a wider range of TypeScript module settings. Additionally, the build process has been enhanced by including the `lsTypes` module in the minification step, ensuring a more efficient production build.