### PR TITLE
feat(api): Expand APIs with new customizable options and enhanced functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,14 @@
 export * from './lsTypes';
 export * from './lsfnd';
 export type {
+  StringPath,
   LsTypes,
   LsTypesInterface,
   LsTypesKeys,
   LsTypesValues,
   LsOptions,
+  ResolvedLsOptions,
+  DefaultLsOptions,
   LsEntries,
   LsResult
 } from '../types';

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -245,7 +245,14 @@ export async function ls(
       + (Array.isArray(options) ? 'array' : typeof options));
   }
 
-  // Resolve its absolute and relative path
+  // Check and resolve the `rootDir` option
+  if (options.rootDir && (options.rootDir instanceof URL
+      || (typeof options.rootDir === 'string' && /^[a-zA-Z]+:/.test(options.rootDir))
+  )) {
+    options.rootDir = fileUrlToPath(options.rootDir);
+  }
+
+  // Resolve the absolute and relative of the dirpath argument
   absdirpath = path.isAbsolute(<StringPath> dirpath)
     ? <StringPath> dirpath
     : path.posix.resolve(<StringPath> dirpath);

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -27,6 +27,13 @@ import type {
 
 type Unpack<A> = A extends Array<(infer U)> ? U : A;
 
+/**
+ * An object containing all default values of {@link LsOptions `LsOptions`} type.
+ *
+ * @since 1.0.0
+ * @see   {@link DefaultLsOptions}
+ * @see   {@link LsOptions}
+ */
 export const defaultLsOptions: DefaultLsOptions = {
   encoding: 'utf8',
   recursive: false,
@@ -122,6 +129,17 @@ function checkType<N extends null | undefined>(
   return;
 }
 
+/**
+ * Resolves the given `options` ({@link LsOptions}).
+ *
+ * @param options - An object represents the options to be resolved. Set to `null`
+ *                  or `undefined` to gets the default options.
+ * @returns A new object represents the resolved options. Returns the default
+ *          options if the `options` parameter not specified or `null`.
+ *
+ * @since 1.0.0
+ * @internal
+ */
 function resolveOptions(options: LsOptions | null | undefined): ResolvedLsOptions {
   return <ReturnType<(typeof resolveOptions)>> (!options ? defaultLsOptions : {
     encoding: options?.encoding || defaultLsOptions.encoding,

--- a/test/lsfnd.spec.cjs
+++ b/test/lsfnd.spec.cjs
@@ -14,21 +14,21 @@ const rootDirPosix = path.posix.resolve('..');
 console.log(`\n\x1b[1m${path.basename(__filename)}:\x1b[0m`);
 
 it('test `ls` function by listing this file directory', async () => {
-  const results = await ls(__dirname, {}, 0);
+  const results = await ls(__dirname, { absolute: true }, 0);
   const expected = [ 'lib', 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
     .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
 it('test `lsFiles` function by listing this file directory', async () => {
-  const results = await lsFiles(__dirname);
+  const results = await lsFiles(__dirname, { absolute: true });
   const expected = [ 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
     .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
 it('test `lsDirs` function by listing this file directory', async () => {
-  const results = await lsDirs(__dirname);
+  const results = await lsDirs(__dirname, { absolute: true });
   const expected = [ 'lib' ].map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);

--- a/test/lsfnd.spec.mjs
+++ b/test/lsfnd.spec.mjs
@@ -18,21 +18,21 @@ const rootDirPosix = path.posix.resolve('..');
 console.log(`\n\x1b[1m${path.basename(__filename)}:\x1b[0m`);
 
 it('test `ls` function by listing this file directory', async () => {
-  const results = await ls(__dirname, {}, 0);
+  const results = await ls(__dirname, { absolute: true }, 0);
   const expected = [ 'lib', 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
     .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
 it('test `lsFiles` function by listing this file directory', async () => {
-  const results = await lsFiles(__dirname);
+  const results = await lsFiles(__dirname, { absolute: true });
   const expected = [ 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
     .map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);
 
 it('test `lsDirs` function by listing this file directory', async () => {
-  const results = await lsDirs(__dirname);
+  const results = await lsDirs(__dirname, { absolute: true });
   const expected = [ 'lib' ].map((e) => path.join(__dirname, e));
   deepEq(results, expected);
 }, false);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -130,7 +130,7 @@ export declare interface LsOptions {
    * @defaultValue `'.'` or `process.cwd()`
    * @since        1.0.0
    */
-  rootDir?: StringPath | undefined;
+  rootDir?: StringPath | URL | undefined;
   /**
    * Determines whether to return absolute paths for all entries.
    *
@@ -249,7 +249,7 @@ export declare interface DefaultLsOptions {
   readonly recursive: false;
   readonly match: RegExp;
   readonly exclude: undefined;
-  readonly rootDir: StringPath;
+  readonly rootDir: StringPath | URL;
   readonly absolute: false;
   readonly basename: false;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -85,7 +85,8 @@ export declare interface LsTypesInterface {
 
 /**
  * This interface defines the optional configuration options that can be passed
- * to the `ls*` function. These options control the behavior of the file listing.
+ * to every `ls*` functions. These options control the behavior of the directory listing.
+ *
  * @interface
  * @since 0.1.0
  */
@@ -93,17 +94,20 @@ export declare interface LsOptions {
   /**
    * Specifies the character encoding to be used when reading a directory. 
    * @defaultValue `'utf8'`
+   * @since        0.1.0
    */
   encoding?: BufferEncoding | undefined;
   /**
    * A boolean flag indicating whether to include subdirectories in the listing. 
    * @defaultValue `false`
+   * @since        0.1.0
    */
   recursive?: boolean | undefined;
   /**
    * A regular expression or string pattern used to filter the listed entries. 
    * Only entries matching the pattern will be included in the results.
    * @defaultValue `/.+/` (match all files)
+   * @since        0.1.0
    */
   match?: RegExp | string | undefined;
   /**
@@ -111,8 +115,108 @@ export declare interface LsOptions {
    * listing. Any entries matching this pattern will be filtered out of the 
    * results, even if they match the {@link match} pattern.
    * @defaultValue `undefined`
+   * @since        0.1.0
    */
   exclude?: RegExp | string | undefined;
+  /**
+   * A string path representing the root directory to resolve the results to
+   * relative paths.
+   *
+   * This option will be ignored if either one of the {@link absolute `absolute`}
+   * or {@link basename `basename`} option are enabled, this is due to their
+   * higher priority. This option have the lowest priority when compared with those
+   * options.
+   *
+   * @defaultValue `'.'` or `process.cwd()`
+   * @since        1.0.0
+   */
+  rootDir?: StringPath | undefined;
+  /**
+   * Determines whether to return absolute paths for all entries.
+   *
+   * When enabled (i.e., set to `true`), each entry of the returned results
+   * will be an absolute path. Otherwise, paths will be relative to the directory
+   * specified in the {@link rootDir `rootDir`} field.
+   *
+   * Enabling this option are equivalent with the following code.
+   * Let's assume we want to list all files within a directory named `'foo'`:
+   *
+   * ```js
+   * const { resolve } = require('node:path');
+   * const { lsFiles } = require('lsfnd');
+   * // Or ESM:
+   * // import { resolve } from 'node:path';
+   * // import { lsFiles } from 'lsfnd';
+   *
+   * const absfiles = (await lsFiles('foo/')).map((entry) => resolve(entry));
+   * ```
+   *
+   * In previous release (prior to version 0.1.0) you can literally use an
+   * explicit method that makes the returned results as absolute paths entirely.
+   * That is by utilizing the `path.resolve` function, here is an example:
+   *
+   * ```js
+   * const absfiles = await lsFiles(path.resolve('foo/'));
+   * ```
+   *
+   * In the above code, the directory path is resolved to an absolute path before
+   * being passed to the {@link !lsfnd~lsFiles `lsFiles`} function. As a result,
+   * the function treats the specified directory path as a relative path and
+   * does not attempt to resolve it back to a relative path, thus returning
+   * absolute paths. This approach was considered unstable and problematic due
+   * to inconsistencies in the internal logic. Therefore, this option was
+   * introduced as a replacement and will default returns relative paths when
+   * this option are disabled (set to `false` or unspecified), they will relative
+   * to the path specified in the {@link rootDir `rootDir`} field. Refer to
+   * {@link rootDir `rootDir`} option for more details.
+   *
+   * @defaultValue `false`
+   * @since        1.0.0
+   * @see          {@link rootDir}
+   */
+  absolute?: boolean | undefined;
+  /**
+   * Whether to make the returned result paths only have their basenames, trimming any
+   * directories behind the path separator (i.e., `\\` in Windows, and `/` in POSIX).
+   *
+   * When set to `true`, the returned paths will only include the file and/or
+   * directory names itself. This can be useful if you need only the names while
+   * listing a directory.
+   *
+   * If you enabled both this option and the {@link absolute `absolute`} option,
+   * the `absolute` option will be treated instead due to its higher priority rather
+   * than this option's priority.
+   *
+   * > ### Note  
+   * > Please note, that this option implicitly includes any directories on the
+   * > returned entries. If you want to only include the filenames, then
+   * > combine this option with {@link !lsTypes~lsTypes.LS_F `LS_F`} type if you
+   * > are using {@link !lsfnd~ls `ls`} function, or use this option with
+   * > {@link !lsfnd~lsFiles `lsFiles`} function for better flexibility.
+   *
+   * This option achieves the same functionality as the following code:
+   *
+   * ```js
+   * const path = require('node:path');
+   * // Or ESM:
+   * // import * as path from 'node:path';
+   *
+   * // Assume you have `results` variable contains all files paths
+   * // from listing a directory using `lsFiles` function
+   * const baseResults = results.map((res) => res.split(path.sep).pop());
+   * ```
+   *
+   * Or even a bit more simple like this:
+   * ```js
+   * // ...
+   * const baseResults = results.map((res) => path.basename(res));
+   * ```
+   *
+   * @defaultValue `false`
+   * @since        1.0.0
+   * @see          {@link rootDir}
+   */
+  basename?: boolean | undefined;
 }
 
 /**
@@ -141,12 +245,13 @@ export declare type ResolvedLsOptions = {
  * @see       {@link !lsfnd~defaultLsOptions defaultLsOptions}
  */
 export declare interface DefaultLsOptions {
-  encoding: 'utf8';
-  recursive: false;
-  match: RegExp;
-  exclude: undefined;
-  rootDir: StringPath;
-  basename: false;
+  readonly encoding: 'utf8';
+  readonly recursive: false;
+  readonly match: RegExp;
+  readonly exclude: undefined;
+  readonly rootDir: StringPath;
+  readonly absolute: false;
+  readonly basename: false;
 }
 
 // ====== APIs ===== //

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,13 +13,19 @@
 /// <reference types="node" />
 
 /**
- * This type alias represents an array of strings. It is typically used to
+ * A type representing the string path.
+ * @since 1.0.0
+ */
+export declare type StringPath = string;
+
+/**
+ * This type alias represents an array of {@link StringPath}. It is typically used to
  * represent the list of file and/or directory entries returned by the `ls*` functions.
- * Each string in the array represents the path of a file or directory within
+ * Each entry in the array represents the path of a file or directory within
  * the listed directory.
  * @since 0.1.0
  */
-export declare type LsEntries = Array<string>;
+export declare type LsEntries = Array<StringPath>;
 
 /**
  * This type alias represents the possible return values of the `ls*` functions.
@@ -31,8 +37,9 @@ export declare type LsResult = LsEntries | null;
 
 /**
  * A combination union types containing all possible values used to specify the
- *  returned results on {@link !lsfnd~ls ls} function.
+ * returned results on {@link !lsfnd~ls ls} function.
  * @since 1.0.0
+ * @see {@link !lsTypes~lsTypes lsTypes}
  */
 export declare type LsTypes = LsTypesKeys | LsTypesValues;
 
@@ -47,12 +54,9 @@ export declare type LsTypesKeys = keyof LsTypesInterface;
  * Type representing all possible values of the {@link lsTypes} enum.
  * @since 0.1.0
  * @see {@link LsTypesInterface}
+ * @see {@link LsTypesKeys}
  */
-export declare type LsTypesValues =
-  | 0b00   // 0 (interpreted the same as LS_A | 1)
-  | 0b01   // 1 (LS_A)
-  | 0b10   // 2 (LS_D)
-  | 0b100  // 4 (LS_F)
+export declare type LsTypesValues = keyof typeof LsTypesInterface;
 
 /**
  * Interface defining the {@link lsTypes} enum with string literal keys
@@ -66,17 +70,17 @@ export declare interface LsTypesInterface {
    * Represents an option to include all file types.
    * @defaultValue `0b01 << 0b00` (`0b01` | `0o01` | `0x01` | `1`)
    */
-  readonly LS_A: number;  // ALL
+  readonly LS_A: 0b01;   // ALL
   /**
    * Represents an option to include only the directory type.
    * @defaultValue `0b01 << 0b01` (`0b10` | `0o02` | `0x02` | `2`)
    */
-  readonly LS_D: number;  // DIRECTORY
+  readonly LS_D: 0b10;   // DIRECTORY
   /**
    * Represents an option to include only the file type.
    * @defaultValue `0b01 << 0b10` (`0b100` | `0o04` | `0x04` | `4`)
    */
-  readonly LS_F: number;  // FILE
+  readonly LS_F: 0b100;  // FILE
 }
 
 /**
@@ -90,25 +94,59 @@ export declare interface LsOptions {
    * Specifies the character encoding to be used when reading a directory. 
    * @defaultValue `'utf8'`
    */
-  encoding?: BufferEncoding | undefined,
+  encoding?: BufferEncoding | undefined;
   /**
    * A boolean flag indicating whether to include subdirectories in the listing. 
    * @defaultValue `false`
    */
-  recursive?: boolean | undefined,
+  recursive?: boolean | undefined;
   /**
    * A regular expression or string pattern used to filter the listed entries. 
    * Only entries matching the pattern will be included in the results.
    * @defaultValue `/.+/` (match all files)
    */
-  match?: RegExp | string | undefined,
+  match?: RegExp | string | undefined;
   /**
    * A regular expression or string pattern used to exclude entries from the 
    * listing. Any entries matching this pattern will be filtered out of the 
    * results, even if they match the {@link match} pattern.
    * @defaultValue `undefined`
    */
-  exclude?: RegExp | string | undefined
+  exclude?: RegExp | string | undefined;
+}
+
+/**
+ * Represents resolved options type for the `ls*` functions, where all properties are
+ * required and both `null` and `undefined` values are omitted, except for the
+ * {@link LsOptions.exclude `exclude`} property which keeps the `undefined` type.
+ *
+ * @since 1.0.0
+ * @see   {@link LsOptions}
+ * @see   {@link DefaultLsOptions}
+ */
+export declare type ResolvedLsOptions = {
+  [T in keyof LsOptions]-?: T extends 'exclude'
+    ? NonNullable<LsOptions[T]> | undefined
+    : NonNullable<LsOptions[T]>
+};
+
+/**
+ * Represents the default options type for the `ls*` functions, used by
+ * {@link !lsfnd~defaultLsOptions `defaultLsOptions`}.
+ *
+ * @interface
+ * @since     1.0.0
+ * @see       {@link LsOptions}
+ * @see       {@link ResolvedLsOptions}
+ * @see       {@link !lsfnd~defaultLsOptions defaultLsOptions}
+ */
+export declare interface DefaultLsOptions {
+  encoding: 'utf8';
+  recursive: false;
+  match: RegExp;
+  exclude: undefined;
+  rootDir: StringPath;
+  basename: false;
 }
 
 // ====== APIs ===== //
@@ -128,20 +166,20 @@ export declare const lsTypes: Record<
 
 /** {@inheritDoc !lsfnd~ls} */
 export declare function ls(
-  dirpath: string | URL,
+  dirpath: StringPath | URL,
   options?: LsOptions | RegExp | undefined,
   type?: LsTypes | undefined
 ): Promise<LsResult>
 
 /** {@inheritDoc !lsfnd~lsFiles} */
 export declare function lsFiles(
-  dirpath: string | URL,
+  dirpath: StringPath | URL,
   options?: LsOptions | RegExp | undefined
 ): Promise<LsResult>
 
 /** {@inheritDoc !lsfnd~lsDirs} */
 export declare function lsDirs(
-  dirpath: string | URL,
+  dirpath: StringPath | URL,
   options?: LsOptions | RegExp | undefined
 ): Promise<LsResult>
 


### PR DESCRIPTION
## Overview

This pull request introduces several enhancements and additions to the LSFND package, focusing on enhancing APIs usage by introducing some additional options, and refining type declarations to more robust and compatible with these changes and future changes.

## Notable Changes

- Addition of several new API options, including `absolute`, `rootDir`, and `basename` option to `LsOptions` (i.e., the `options` parameter of `ls*` functions).
- Introduced a new constant object represents the default options of `LsOptions`, this is publicly visible.
- Improvements to type declarations, ensuring type safety, compatibility, and improving code robustness.

## Details

### APIs Enhancements

- Introduced several new API options:
  - `absolute`: Determines whether to return absolute paths for all entries.
  - `basename`: Controls whether returned entries include only file and/or directory names.
  - `rootDir`: Specifies the root directory to resolve relative paths.


> [!NOTE]\
> These options have priority tiers, with the highest priority being at the top of the list. For example, if both `rootDir` and `absolute` are specified, `absolute` takes precedence.
> 
> The `basename` option implicitly includes any directories on the returned entries. If you want to only include the filenames, then combine this option with `lsTypes.LS_F` type if you are using `ls` function, or use this option with `lsFiles` function for better flexibility.

> [!WARNING]\
> **THIS MIGHT BREAKING CHANGES!**
> 
> In previous release (prior to version [0.1.0](https://github.com/mitsuki31/lsfnd/releases/tag/v0.1.0)) you can literally use an explicit method that makes the returned results as absolute paths entirely. That is by utilizing the `path.resolve` function, here is an example:
> 
> ```js
> const absfiles = await lsFiles(path.resolve('foo'));
> ```
>
> In the above code, the directory path is resolved to an absolute path before being passed to the `lsFiles` function. As a result, the function treats the specified directory path as a relative path and does not attempt to resolve it back to a relative path, thus returning absolute paths. This approach was considered unstable and problematic due to inconsistencies in the internal logic.
> Therefore, the `absolute` option was introduced as a replacement and will default returns relative paths when this option are disabled (set to `false` or unspecified), they will relative to the path specified in the `rootDir` option.

- Added support for file URLs in the `rootDir` option. Note that only URLs with the `'file:'` protocol are supported, and attempting to use other protocols will result in an error. This option uses the same logic resolution as the `dirpath` parameter, which you can pass a relative path of file URL string like this:

  ```js
  lsDirs('file:./a/b/c', { rootDir: 'file:./a' });
  // Output: b/c
  ```

- Enhanced the resolution of the `options` parameter by defining a new internal function called `resolveOptions`. This improves flexibility and reduces code duplication while ensuring type strictness.

- Introduced the `defaultLsOptions` constant object, containing all default options for `ls*` functions.

#### Types Declaration

- Declared a new type called `StringPath` representing a path from a string.
- Refactored and improved type declarations, including changes to `LsOptionsInterface`, `LsTypesValues`, `ResolvedLsOptions`, and `DefaultLsOptions`.

### Documentation

- Added TypeDoc documentation for the `defaultLsOptions` object and the `resolveOptions` internal function.

## Summary

These changes significantly enhance the LSFND package by introducing new API options, improving options handling and documentation, and refining type declarations. These enhancements contribute to better usability, flexibility, and correctness of the package.
