### PR TITLE
fix(encoding): Fix malfunctioning encoding option

### DIFF
--- a/test/lsfnd.spec.cjs
+++ b/test/lsfnd.spec.cjs
@@ -49,6 +49,15 @@ it('test if the type argument accepts a string value', async () => {
   await doesNotReject(ls(__dirname, {}, 'LS_D'), TypeError);
 }, false);
 
+it("list this file directory with 'base64' encoding", async () => {
+  const results = await ls(__dirname, { rootDir: __dirname, encoding: 'base64' });
+  const expected = [ 'lib', 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
+    .map((e) => Buffer.from(e, 'utf8').toString('base64'));
+  deepEq(results, expected);
+}, false);
+
+// --- [ ERROR TESTS ] --- //
+
 it('throws an error if the given directory path not exist', async () => {
   await rejects(ls('./this/is/not/exist/directory/path'), Error);
 }, false);
@@ -65,3 +74,8 @@ it('throws a `TypeError` if the given type is an unexpected value',
   },
   false
 );
+
+it('throws an error if the given encoding option is unknown', async () => {
+  await rejects(lsFiles(__dirname, { encoding: 'NotDefinedEncoding' }), TypeError);
+  await rejects(lsFiles(__dirname, { encoding: true }), TypeError);
+});

--- a/test/lsfnd.spec.mjs
+++ b/test/lsfnd.spec.mjs
@@ -53,6 +53,15 @@ it('test if the type argument accepts a string value', async () => {
   await doesNotReject(ls(__dirname, {}, 'LS_D'), TypeError);
 }, false);
 
+it("list this file directory with 'base64' encoding", async () => {
+  const results = await ls(__dirname, { rootDir: __dirname, encoding: 'base64' });
+  const expected = [ 'lib', 'lsfnd.spec.cjs', 'lsfnd.spec.mjs' ]
+    .map((e) => Buffer.from(e, 'utf8').toString('base64'));
+  deepEq(results, expected);
+}, false);
+
+// --- [ ERROR TESTS ] --- //
+
 it('throws an error if the given directory path not exist', async () => {
   await rejects(ls('./this/is/not/exist/directory/path'), Error);
 }, false);
@@ -69,3 +78,8 @@ it('throws a `TypeError` if the given type is an unexpected value',
   },
   false
 );
+
+it('throws an error if the given encoding option is unknown', async () => {
+  await rejects(lsFiles(__dirname, { encoding: 'NotDefinedEncoding' }), TypeError);
+  await rejects(lsFiles(__dirname, { encoding: true }), TypeError);
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -92,7 +92,9 @@ export declare interface LsTypesInterface {
  */
 export declare interface LsOptions {
   /**
-   * Specifies the character encoding to be used when reading a directory. 
+   * Specifies the character encoding to be used for the output encoding of
+   * returned entries.
+   *
    * @defaultValue `'utf8'`
    * @since        0.1.0
    */


### PR DESCRIPTION
## Overview

This pull request addresses an issue with the `encoding` option in the `ls` function, where it was previously malfunctioning and limited to certain encodings such as `'utf8'`, `'binary'`, and `'ascii'`. The issue caused errors when using other encodings such as `'hex'`. The problem has been resolved, and the `encoding` option now works as expected, allowing for more flexibility and robustness in encoding file paths.

## Details

### APIs Enhancements

- Resolved the malfunctioning of the `encoding` option in the `ls` function, which previously only supported a limited set of encodings.
- The issue stemmed from internal errors when using encodings such as `'base64'`, leading to invalid path errors.
- The problem has been fixed by improving the resolution logic of the `encoding` option and implementing the `encodeTo` internal function to handle encoding and decoding of file paths.
- The `encoding` option now supports a wider range of encodings and works as expected, providing users with more flexibility in encoding file paths.

Let's assume you have a tree directory like this:

```
.
├── foo.js
├── README.md
└── LICENSE.txt
```

And you have this code inside the `foo.js` file to list the directory with `'base64'` encoding:

```js
// foo.js
const { ls } = require('lsfnd');
// Or ESM:  import { ls } from 'lsfnd';

ls('.', { encoding: 'base64' }).then((res) => console.log(res));
```

Before this change, you might see an error like this:
```
Uncaught Error: ENOENT: no such file or directory, stat ...
```

But, after this change now you can see the expected result:
```
[ 'TElDRU5TRS50eHQ=', 'UkVBRE1FLm1k', 'Zm9vLmpz' ]
```

### Test Environments

- Added new test cases to thoroughly test the `encoding` option in various scenarios, ensuring its functionality and reliability.

## Summary

This pull request resolves an issue with the `encoding` option in the `ls` function, improving its functionality and reliability. With these changes, users can now specify a wider range of encodings, allowing for more flexibility in handling file paths.