### PR TITLE
fix(build): Resolve bad invocation shell

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -121,6 +121,7 @@ async function minify(files: Array<string>): Promise<void> {
   const tsc: ChildProcess = spawn(tscCmd[0], tscCmd.slice(1), {
     cwd: rootDir,
     stdio: 'inherit',
+    shell: true,
     windowsHide: true
   });
 


### PR DESCRIPTION
## Summary

Before, during the building procedure, there was a problem with the invocation shell in the child process that used `child_process.spawn`. In Windows, this resulted in the process issuing an ENOENT error since the command was not recognized. However, with this modification, we resolved the issue and it now functions correctly in Windows by activating the `shell` option within the options argument (3rd argument) of the `spawn` function.

> [!NOTE]
> Tested in PowerShell and MSYS2 MinTTY. This change are exclusively to Windows users and developers.
