### PR TITLE
refactor(ls): Enhance compatibility and optimize path handling for Windows system

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
+        os: [ Windows, Ubuntu ]
         node-ver: [16.x, 18.x, 20.x]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "build:docs": "typedoc --options typedoc.config.js",
     "test": "node test/lsfnd.spec.cjs && node test/lsfnd.spec.mjs",
     "test:cjs": "node test/lsfnd.spec.cjs",
-    "test:mjs": "node test/lsfnd.spec.mjs"
+    "test:mjs": "node test/lsfnd.spec.mjs",
+    "prepublishOnly": "ts-node scripts/build.ts --overwrite",
+    "prepack": "npm test"
   },
   "repository": {
     "type": "git",

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -11,18 +11,19 @@
  */
 
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { URL, fileURLToPath } from 'node:url';
-import { lsTypes }  from './lsTypes';
 import type {
-  StringPath,
-  LsEntries,
-  LsResult,
-  LsOptions,
-  ResolvedLsOptions,
   DefaultLsOptions,
-  LsTypes
+  LsEntries,
+  LsOptions,
+  LsResult,
+  LsTypes,
+  ResolvedLsOptions,
+  StringPath
 } from '../types';
+import { lsTypes } from './lsTypes';
 
 type Unpack<A> = A extends Array<(infer U)> ? U : A;
 
@@ -90,6 +91,7 @@ export const defaultLsOptions: DefaultLsOptions = {
  * @see   {@link https://nodejs.org/api/url.html#urlfileurltopathurl url.fileURLToPath}
  *
  * @internal
+ * @deprecated
  */
 function fileUrlToPath(url: URL | StringPath): StringPath {
   if ((url instanceof URL && url.protocol !== 'file:')

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -28,6 +28,22 @@ import type {
 type Unpack<A> = A extends Array<(infer U)> ? U : A;
 
 /**
+ * A regular expression pattern to parse the file URL path,
+ * following the WHATWG URL Standard.
+ * 
+ * @see {@link https://url.spec.whatwg.org/ WHATWG URL Standard}
+ * @internal
+ */
+const FILE_URL_PATTERN: RegExp = /^file:\/\/\/?(?:[A-Za-z]:)?(?:\/[^\s\\]+)*(?:\/)?/;
+
+/**
+ * A regular expression pattern to parse and detect the Windows path.
+ *
+ * @internal
+ */
+const WIN32_PATH_PATTERN: RegExp = /^[A-Za-z]:?(?:\\|\/)(?:[^\\/:*?"<>|\r\n]+(?:\\|\/))*[^\\/:*?"<>|\r\n]*$/;
+
+/**
  * An object containing all default values of {@link LsOptions `LsOptions`} type.
  *
  * @since 1.0.0
@@ -84,6 +100,22 @@ function fileUrlToPath(url: URL | StringPath): StringPath {
   return (url instanceof URL)
     ? fileURLToPath(url).replaceAll(/\\/g, '/')
     : url.replace(/^file:/, '');
+}
+
+/**
+ * Checks if the given string path is a Windows path.
+ *
+ * Before checking, the given path will be normalized first.
+ *
+ * @param p - The string path to be checked for.
+ * @returns   `true` if the given path is a Windows path, `false` otherwise.
+ * @see       {@link WIN32_PATH_PATTERN}
+ *
+ * @internal
+ */
+function isWin32Path(p: StringPath): boolean {
+  p = path.normalize(p);
+  return !!p && WIN32_PATH_PATTERN.test(p);
 }
 
 /**

--- a/src/lsfnd.ts
+++ b/src/lsfnd.ts
@@ -169,7 +169,8 @@ function resolveFileURL(p: StringPath): StringPath {
     if (/^file:(?:\/\/\/?)$/.test(p)) p = '/';
     // Otherwise, parse the file URL path
     else p = fileURLToPath(p);
-  } else if ((os.platform() !== 'win32' && isWin32Path(p))
+  } else if ((os.platform() !== 'win32'
+      && (isWin32Path(p) || !p.startsWith('file:')))
       || (os.platform() === 'win32'
         && !(isWin32Path(p) || p.startsWith('file:')))) {
     throw new URIError('Invalid file URL scheme');

--- a/test/lib/simpletest.js
+++ b/test/lib/simpletest.js
@@ -26,8 +26,8 @@ const assert = require('node:assert');
  * A custom class representing the error thrown by {@link module:simpletest~it} function.
  */
 class TestError extends Error {
-  constructor(message) {
-    super(message);  // Important
+  constructor(message, opts) {
+    super(message, opts);  // Important
     this.name = 'TestError';
   }
 }
@@ -47,7 +47,7 @@ async function it(desc, func, continueOnErr=false) {
     console.log(`  \x1b[92m\u2714 \x1b[0m\x1b[2m${desc}\x1b[0m`);
   } catch (err) {
     console.error(`  \x1b[91m\u2718 \x1b[0m${desc}\n`);
-    console.error(new TestError(err.message));
+    console.error(new TestError('Test failed!', { cause: err }));
     !!continueOnErr || process.exit(1);  // Force terminate the process
   }
 }

--- a/test/lsfnd.spec.cjs
+++ b/test/lsfnd.spec.cjs
@@ -9,7 +9,7 @@ const { ls, lsFiles, lsDirs } = require('..');
 const { it, rejects, doesNotReject, deepEq } = require('./lib/simpletest');
 
 const rootDir = path.resolve('..');
-const rootDirPosix = path.posix.resolve('..');
+const rootDirPosix = rootDir.replaceAll(path.sep, '/');
 
 console.log(`\n\x1b[1m${path.basename(__filename)}:\x1b[0m`);
 
@@ -38,7 +38,7 @@ it('list root directory using URL object', async () => {
 }, false);
 
 it('list root directory using file URL path', async () => {
-  await doesNotReject(ls('file:'.concat(rootDirPosix)), URIError);
+  await doesNotReject(ls(pathToFileURL(rootDirPosix)), URIError);
 }, false);
 
 it('test if the options argument allows explicit null value', async () => {
@@ -63,7 +63,7 @@ it('throws an error if the given directory path not exist', async () => {
 }, false);
 
 it('throws a `URIError` if the given file URL path using unsupported protocol',
-  async () => await rejects(ls('http:'.concat(rootDirPosix)), URIError),
+  async () => await rejects(ls('http:///'.concat(rootDirPosix)), URIError),
   false
 );
 

--- a/test/lsfnd.spec.mjs
+++ b/test/lsfnd.spec.mjs
@@ -13,7 +13,7 @@ const { it, rejects, doesNotReject, deepEq } = test;  // Resolve import from Com
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const rootDir = path.resolve('..');
-const rootDirPosix = path.posix.resolve('..');
+const rootDirPosix = rootDir.replaceAll(path.sep, '/');
 
 console.log(`\n\x1b[1m${path.basename(__filename)}:\x1b[0m`);
 
@@ -42,7 +42,7 @@ it('list root directory using URL object', async () => {
 }, false);
 
 it('list root directory using file URL path', async () => {
-  await doesNotReject(ls('file:'.concat(rootDirPosix)), URIError);
+  await doesNotReject(ls(pathToFileURL(rootDirPosix)), URIError);
 }, false);
 
 it('test if the options argument allows explicit null value', async () => {
@@ -67,7 +67,7 @@ it('throws an error if the given directory path not exist', async () => {
 }, false);
 
 it('throws an URIError if the given file URL path using unsupported protocol',
-  async () => await rejects(ls('http:'.concat(rootDirPosix)), URIError),
+  async () => await rejects(ls('http:///'.concat(rootDirPosix)), URIError),
   false
 );
 


### PR DESCRIPTION
## Overview

This pull request introduces several enhancements and fixes aimed at improving support for Windows systems. Notable changes include additions of new functions for resolving file URLs and detecting Windows paths, along with fixes for path resolution issues and improvements in error handling. Additionally, there are updates to scripts and deprecation of internal function for better code organization.

## Notable Changes

### Refactors and Improvements

  - Added new npm scripts for project building and testing (see 62bce18 to check all added scripts).
  - Added a new function to resolve file URL paths, along with regex and function for path detection.
  - Enhanced Windows path resolution in the `ls` function to handle drive letter paths.
  - Addressed errors while stating read-protected entries and improved directory entry handling.
  - Re-sorted imports in `lsfnd` module for better code maintenance.

### Deprecation

  - Deprecated an internal function (`fileUrlToPath`). Because it doesn't follows the URL Standard specification and causing an issue to `ls` function, especially in Windows systems. It might be replaced by new function called `resolveFileURL` which better on resolving the file URL path (but it only accepts a string path).
    > `resolveFileURL` definition:
    > ```ts
    > function resolveFileURL(p: StringPath): StringPath;
    > ```

### Test Environments

  - Fixed issues with POSIX and file URL path resolution.
  - Refactored the `TestError` class constructor and error handling in tests.

## Summary

These changes focus on resolving an issue and enhancing stability and functionality for Windows systems. The root problem stemmed from drive letter paths being treated as file URL paths, leading to internal errors that couldn't be fixed by external logic.

In addition, we refactored the `ls` function to handle file URL paths more effectively. Relative file URL paths, such as `'file:./'` or `'file:../'`, are no longer supported and have been removed to ensure compliance with the [**WHATWG URL Standard**](https://url.spec.whatwg.org/) specification.

Overall, these adjustments aim to bolster the project's reliability and functionality on Windows systems while simultaneously improving code maintainability.

> [!NOTE]\
> These changes have been thoroughly tested on Windows operating systems using both **PowerShell** and **MinGW** shell environments to ensure compatibility and reliability.